### PR TITLE
Updated for Xcode project uniformity

### DIFF
--- a/L01_Camera/xcode/L01_Camera.xcodeproj/project.pbxproj
+++ b/L01_Camera/xcode/L01_Camera.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				00FF35C71B27A89D00C32278 /* L01_CameraApp.cpp */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -140,7 +141,6 @@
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				00FF35C71B27A89D00C32278 /* L01_CameraApp.cpp */,
 				801B04B88E0144388D6F2F64 /* CinderApp.icns */,
 				17A4EC07C96548DE8C2F9760 /* Info.plist */,
 			);
@@ -230,7 +230,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = $HOME/Playground/cinder_glNext;
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -256,7 +256,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = $HOME/Playground/cinder_glNext;
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L02_BasicScene/xcode/L02_BasicScene.xcodeproj/project.pbxproj
+++ b/L02_BasicScene/xcode/L02_BasicScene.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				00FF35C91B27AB6900C32278 /* L02_BasicSceneApp.cpp */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -143,7 +144,6 @@
 			isa = PBXGroup;
 			children = (
 				00FF35D11B27AEFC00C32278 /* assets */,
-				00FF35C91B27AB6900C32278 /* L02_BasicSceneApp.cpp */,
 				801B04B88E0144388D6F2F64 /* CinderApp.icns */,
 				17A4EC07C96548DE8C2F9760 /* Info.plist */,
 			);
@@ -234,7 +234,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = $HOME/Playground/cinder_glNext;
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -260,7 +260,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = $HOME/Playground/cinder_glNext;
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L03_Lighting_I/xcode/L03_Lighting_I.xcodeproj/project.pbxproj
+++ b/L03_Lighting_I/xcode/L03_Lighting_I.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -259,6 +260,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L04_Lighting_II/xcode/L04_Lighting_II.xcodeproj/project.pbxproj
+++ b/L04_Lighting_II/xcode/L04_Lighting_II.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -259,6 +260,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L05_Lighting_III/xcode/L05_Lighting_III.xcodeproj/project.pbxproj
+++ b/L05_Lighting_III/xcode/L05_Lighting_III.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -261,6 +262,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L06_Instancing/xcode/L06_Instancing.xcodeproj/project.pbxproj
+++ b/L06_Instancing/xcode/L06_Instancing.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -261,6 +262,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L07_Motion_I/xcode/L07_Motion_I.xcodeproj/project.pbxproj
+++ b/L07_Motion_I/xcode/L07_Motion_I.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -261,6 +262,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L08_Motion_II/xcode/L08_Motion_II.xcodeproj/project.pbxproj
+++ b/L08_Motion_II/xcode/L08_Motion_II.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -261,6 +262,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L09_Motion_III/xcode/L09_Motion_III.xcodeproj/project.pbxproj
+++ b/L09_Motion_III/xcode/L09_Motion_III.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -263,6 +264,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/L10_FBO/xcode/L10_FBO.xcodeproj/project.pbxproj
+++ b/L10_FBO/xcode/L10_FBO.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -263,6 +264,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = ../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@ A series of tutorials designed to get folks up and running with Cinder (glNext/0
 
 ## UNDER CONSTRUCTION
 ![Header Image](https://lh3.googleusercontent.com/-j50yAJ2gew0/VXH_nF5fkNI/AAAAAAAAB48/NPwQ8ivbY-o/s800/cindertuts.png)
+
+###Setup for XCode Users:
+Place these in your cinder folder inside another directory - such as: `Cinder_Root_Directory/samples`
+
+So the path to the XCode file for L01_Camera would be: `Cinder_Root_Directory/samples/LearnCinderGL/L01_Camera/xcode/L01_Camera.xcodeproj`
+
+If you want to put the apps in another location, you just need to change this in your project Build settings - all the way at the bottom of the "Build Settings" tab on the project settings, there is a variable called `CINDER_PATH` it is currently set to `../../../..	` indicating that the path to Cinder's libraries are 4 directories away - if you want to nest these deeper or more shallow, just change this...


### PR DESCRIPTION
Modified Xcode project files to be more uniform to normal Cinder projects and altered the Cinder Path so they can be placed in the /samples directory
